### PR TITLE
Rename environment variable to RIP_GRAVEYARD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
 
 jobs:
   test:
@@ -50,3 +51,35 @@ jobs:
         run: cargo doc --all --no-deps
       - name: Test with code coverage
         run: cargo tarpaulin --release --engine llvm --follow-exec --post-test-delay 10 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+  release-please:
+    name: Execute release chores
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+    needs: test
+
+    outputs:
+      created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: rust
+
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.created
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Publish
+        run: cargo publish --verbose --locked --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Publish
         run: cargo publish --verbose --locked --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "rip2"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = '2021'
 name = "rip2"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["mail@nivekuil.com", "mahid@standingpad.org", "miles.cranmer@gmail.com"]
 description = "rip: a safe and ergonomic alternative to rm"
 repository = "https://github.com/MilesCranmer/rip"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you have `$XDG_DATA_HOME` environment variable set, `rip` will use `$XDG_DATA
 If you want to put the graveyard somewhere else (like `~/.local/share/Trash`), you have two options, in order of precedence:
 
   1. Alias `rip` to `rip --graveyard ~/.local/share/Trash`
-  2. Set the environment variable `$GRAVEYARD` to `~/.local/share/Trash`.
+  2. Set the environment variable `$RIP_GRAVEYARD` to `~/.local/share/Trash`.
 
 This can be a good idea because if the graveyard is mounted on an in-memory file system (as `/tmp` is in Arch Linux), deleting large files can quickly fill up your RAM.  It's also much slower to move files across file systems, although the delay should be minimal with an SSD.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
     let graveyard: PathBuf = {
         if let Some(flag) = cli.graveyard {
             flag
-        } else if let Ok(env) = env::var("GRAVEYARD") {
+        } else if let Ok(env) = env::var("RIP_GRAVEYARD") {
             PathBuf::from(env)
         } else if let Ok(mut env) = env::var("XDG_DATA_HOME") {
             if !env.ends_with(std::path::MAIN_SEPARATOR) {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -142,7 +142,7 @@ fn test_bury_unbury(#[values(false, true)] decompose: bool, #[values(false, true
     }
 }
 
-const ENV_VARS: [&str; 2] = ["GRAVEYARD", "XDG_DATA_HOME"];
+const ENV_VARS: [&str; 2] = ["RIP_GRAVEYARD", "XDG_DATA_HOME"];
 
 // Delete env vars and return them
 // so we can restore them later
@@ -171,7 +171,7 @@ fn restore_env_vars(default_env_vars: [Option<String>; 2]) {
 
 /// Test that we can set the graveyard from different env variables
 #[rstest]
-fn test_env(#[values("GRAVEYARD", "XDG_DATA_HOME")] env_var: &str) {
+fn test_env(#[values("RIP_GRAVEYARD", "XDG_DATA_HOME")] env_var: &str) {
     let _env_lock = aquire_lock();
 
     let default_env_vars = cache_and_remove_env_vars();


### PR DESCRIPTION
The environment variable used to specify the graveyard location has been renamed from `$GRAVEYARD` to `$RIP_GRAVEYARD`.