### PR TITLE
Use `std::env::temp_dir()` for graveyard path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 `rip` is a rust-based `rm` with a focus on safety, ergonomics, and performance.  It favors a simple interface, and does *not* implement the xdg-trash spec or attempt to achieve the same goals.
 
-Deleted files get sent to the graveyard 🪦 (`/tmp/graveyard-$USER` by default, see [notes](#notes) on changing this) under their absolute path, giving you a chance to recover them 🧟. No data is overwritten. If files that share the same path are deleted, they will be renamed as numbered backups.
+Deleted files get sent to the graveyard 🪦 (Usually `/tmp/graveyard-$USER`, see [notes](#notes) on changing this) under their absolute path, giving you a chance to recover them 🧟. No data is overwritten. If files that share the same path are deleted, they will be renamed as numbered backups.
 
 This version, "rip2", is a fork-of-a-fork:
 
@@ -134,7 +134,7 @@ alias rm="echo Use 'rip' instead of rm."
 
 **Graveyard location.**
 
-If you have `$XDG_DATA_HOME` environment variable set, `rip` will use `$XDG_DATA_HOME/graveyard` instead of the `/tmp/graveyard-$USER`.
+If you have `$XDG_DATA_HOME` environment variable set, `rip` will use `$XDG_DATA_HOME/graveyard` instead of the `$TMPDIR/graveyard-$USER`.
 
 If you want to put the graveyard somewhere else (like `~/.local/share/Trash`), you have two options, in order of precedence:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,12 +441,5 @@ pub fn copy_file(
 
 fn default_graveyard() -> PathBuf {
     let user = util::get_user();
-
-    #[cfg(unix)]
-    let base_path = "/tmp/graveyard";
-
-    #[cfg(target_os = "windows")]
-    let base_path = env::var("TEMP").unwrap_or_else(|_| "C:\\Windows\\Temp".to_string());
-
-    PathBuf::from(format!("{}-{}", base_path, user))
+    env::temp_dir().join(format!("graveyard-{}", user))
 }


### PR DESCRIPTION
It is a potential security vulnerability to use `/tmp` as it may be accessible to multiple users. It is safer and more robust to simply write to whatever the operating system lists as the user's temporary directory. However, this is a breaking change.