### PR TITLE
add graveyard subcommand + help colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 name = "rip2"
 version = "0.5.0"
 dependencies = [
+ "anstyle",
  "assert_cmd",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities"]
 autobins = false
 
 [dependencies]
+anstyle = "1.0.6"
 clap = { version = "4.4", features = ["derive"] }
 clap_complete = "4.4"
 clap_complete_nushell = "4.4"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 `rip` is a rust-based `rm` with a focus on safety, ergonomics, and performance.  It favors a simple interface, and does *not* implement the xdg-trash spec or attempt to achieve the same goals.
 
-Deleted files get sent to the graveyard 🪦 (Usually `/tmp/graveyard-$USER`, see [notes](#notes) on changing this) under their absolute path, giving you a chance to recover them 🧟. No data is overwritten. If files that share the same path are deleted, they will be renamed as numbered backups.
+Deleted files get sent to the graveyard 🪦 (typically `/tmp/graveyard-$USER`, see [notes](#notes) on changing this) under their absolute path, giving you a chance to recover them 🧟. No data is overwritten. If files that share the same path are deleted, they will be renamed as numbered backups.
 
 This version, "rip2", is a fork-of-a-fork:
 
@@ -44,11 +44,7 @@ No binaries are made available at this time.
 ## Usage
 
 ```text
-Usage: rip [OPTIONS] [TARGETS]... [COMMAND]
-
-Commands:
-  completions  Generate shell completions file for the specified shell
-  help         Print this message or the help of the given subcommand(s)
+Usage: rip [OPTIONS] [TARGETS]... [SUB-COMMAND]
 
 Arguments:
   [TARGETS]...  File or directory to remove
@@ -56,11 +52,16 @@ Arguments:
 Options:
       --graveyard <GRAVEYARD>  Directory where deleted files rest
   -d, --decompose              Permanently deletes the graveyard
-  -s, --seance                 Prints files that were deleted in the current working directory
+  -s, --seance                 Prints files that were deleted in the current directory
   -u, --unbury                 Restore the specified files or the last file if none are specified
   -i, --inspect                Print some info about TARGET before burying
   -h, --help                   Print help
   -V, --version                Print version
+
+Sub-commands:
+  completions  Generate shell completions file
+  graveyard    Print the graveyard path
+  help         Print this message or the help of the given subcommand(s)
 ```
 
 Basic usage -- easier than rm
@@ -134,6 +135,7 @@ alias rm="echo Use 'rip' instead of rm."
 
 **Graveyard location.**
 
+You can see the current graveyard location by running `rip graveyard`.
 If you have `$XDG_DATA_HOME` environment variable set, `rip` will use `$XDG_DATA_HOME/graveyard` instead of the `$TMPDIR/graveyard-$USER`.
 
 If you want to put the graveyard somewhere else (like `~/.local/share/Trash`), you have two options, in order of precedence:

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ No binaries are made available at this time.
 ## Usage
 
 ```text
-Usage: rip [OPTIONS] [TARGETS]... [SUB-COMMAND]
+Usage: rip [OPTIONS] [FILES]...
+       rip [SUBCOMMAND]
 
 Arguments:
-  [TARGETS]...  File or directory to remove
+    [FILES]...  Files and directories to remove
 
 Options:
       --graveyard <GRAVEYARD>  Directory where deleted files rest

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,9 +3,27 @@ use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug, Default)]
-#[command(version, about, long_about = None)]
+#[command(
+    name = "rip",
+    version,
+    about,
+    long_about = None,
+    help_template = "\
+Usage: rip [OPTIONS] [FILES]...
+       rip [SUBCOMMAND]
+
+Arguments:
+    [FILES]...  Files or directories to remove
+
+Options:
+{options}
+
+Subcommands:
+{subcommands}
+"
+)]
 pub struct Args {
-    /// File or directory to remove
+    /// Files or directories to remove
     pub targets: Vec<PathBuf>,
 
     /// Directory where deleted files rest

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,7 +46,12 @@ pub enum Commands {
     },
 
     /// Print the graveyard path
-    Graveyard,
+    Graveyard {
+        /// Get the graveyard subdirectory
+        /// of the current directory
+        #[arg(short, long)]
+        seance: bool,
+    },
 }
 
 struct IsDefault {

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,7 +17,7 @@ pub struct Args {
     pub decompose: bool,
 
     /// Prints files that were deleted
-    /// in the current working directory
+    /// in the current directory
     #[arg(short, long)]
     pub seance: bool,
 
@@ -39,12 +39,14 @@ pub struct Args {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Generate shell completions file
-    /// for the specified shell
     Completions {
         /// The shell to generate completions for
         #[arg(value_name = "SHELL")]
         shell: String,
     },
+
+    /// Print the graveyard path
+    Graveyard,
 }
 
 struct IsDefault {

--- a/src/args.rs
+++ b/src/args.rs
@@ -82,7 +82,7 @@ const STYLES: Styles = Styles::styled()
     help_template = help_template("rip"),
 )]
 pub struct Args {
-    /// Files or directories to remove
+    /// Files and directories to remove
     pub targets: Vec<PathBuf>,
 
     /// Directory where deleted files rest
@@ -115,6 +115,7 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Generate shell completions file
     #[command(styles=STYLES, help_template=help_template("completions"))]
     Completions {
         /// The shell to generate completions for
@@ -122,6 +123,7 @@ pub enum Commands {
         shell: String,
     },
 
+    /// Print the graveyard path
     #[command(styles=STYLES, help_template=help_template("graveyard"))]
     Graveyard {
         /// Get the graveyard subdirectory

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::env;
 use std::io;
 use std::process::ExitCode;
 
@@ -19,8 +20,15 @@ fn main() -> ExitCode {
             }
             return ExitCode::SUCCESS;
         }
-        Some(Commands::Graveyard) => {
-            println!("{}", rip2::get_graveyard(None).display());
+        Some(Commands::Graveyard { seance }) => {
+            let graveyard = rip2::get_graveyard(None);
+            if *seance {
+                let cwd = &env::current_dir().unwrap();
+                let gravepath = util::join_absolute(graveyard, dunce::canonicalize(cwd).unwrap());
+                println!("{}", gravepath.display());
+            } else {
+                println!("{}", graveyard.display());
+            }
             return ExitCode::SUCCESS;
         }
         None => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Args as _, ColorChoice, Command, FromArgMatches as _};
 use std::env;
 use std::io;
 use std::process::ExitCode;
@@ -7,7 +7,10 @@ use rip2::args::Commands;
 use rip2::{args, completions, util};
 
 fn main() -> ExitCode {
-    let cli = args::Args::parse();
+    let base_cmd = Command::new("rip").color(ColorChoice::Never);
+    let cmd = args::Args::augment_args(base_cmd);
+    let cli = args::Args::from_arg_matches(&cmd.get_matches()).unwrap();
+
     let mut stream = io::stdout();
     let mode = util::ProductionMode;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use std::io;
 use std::process::ExitCode;
 
+use rip2::args::Commands;
 use rip2::{args, completions, util};
 
 fn main() -> ExitCode {
@@ -10,12 +11,16 @@ fn main() -> ExitCode {
     let mode = util::ProductionMode;
 
     match &cli.command {
-        Some(args::Commands::Completions { shell }) => {
+        Some(Commands::Completions { shell }) => {
             let result = completions::generate_shell_completions(shell, &mut io::stdout());
             if result.is_err() {
                 eprintln!("{}", result.unwrap_err());
                 return ExitCode::FAILURE;
             }
+            return ExitCode::SUCCESS;
+        }
+        Some(Commands::Graveyard) => {
+            println!("{}", rip2::get_graveyard(None).display());
             return ExitCode::SUCCESS;
         }
         None => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Args as _, ColorChoice, Command, FromArgMatches as _};
+use clap::{Args as _, Command, FromArgMatches as _};
 use std::env;
 use std::io;
 use std::process::ExitCode;
@@ -7,7 +7,7 @@ use rip2::args::Commands;
 use rip2::{args, completions, util};
 
 fn main() -> ExitCode {
-    let base_cmd = Command::new("rip").color(ColorChoice::Never);
+    let base_cmd = Command::new("rip");
     let cmd = args::Args::augment_args(base_cmd);
     let cli = args::Args::from_arg_matches(&cmd.get_matches()).unwrap();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -676,3 +676,13 @@ fn issue_0018() {
 
     return;
 }
+
+#[rstest]
+fn test_graveyard_subcommand() {
+    let expected_graveyard = rip2::get_graveyard(None);
+    let expected_graveyard_str = format!("{}\n", expected_graveyard.display());
+    cli_runner(["graveyard"], None)
+        .assert()
+        .success()
+        .stdout(is_match(expected_graveyard_str).unwrap());
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -678,14 +678,13 @@ fn issue_0018() {
 }
 
 #[rstest]
-fn test_graveyard_subcommand(
-    #[values(false, true)] seance: bool,
-) {
+fn test_graveyard_subcommand(#[values(false, true)] seance: bool) {
     let _env_lock = aquire_lock();
 
     let expected_graveyard = rip2::get_graveyard(None);
     let cwd = &env::current_dir().unwrap();
-    let expected_gravepath = util::join_absolute(&expected_graveyard, dunce::canonicalize(cwd).unwrap());
+    let expected_gravepath =
+        util::join_absolute(&expected_graveyard, dunce::canonicalize(cwd).unwrap());
     let expected_str = if seance {
         format!("{}\n", expected_gravepath.display())
     } else {


### PR DESCRIPTION
Easy way to get graveyard path:

```bash
rip graveyard
```

so you can easily check the sizes of its contents with:

```bash
rip graveyard | ls -lath
```

@JeromeSchmied might help with #11. Maybe even a solution to it?