### PR TITLE
Fix flake.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         run: nix-build
       - name: Smoke test default package
         run: ./result/bin/rip --version
+      - name: Test default app
+        run: nix run . -- --help
 
   release-please:
     name: Execute release chores

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,13 @@ jobs:
         run: cargo tarpaulin --release --engine llvm --follow-exec --post-test-delay 10 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   nix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check Nix flake inputs

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,10 @@
             rip2
           ];
         };
+        apps.default = {
+          type = "app";
+          program = "${rip2}/bin/rip";
+        };
       };
     };
 }


### PR DESCRIPTION
I think the reason `nix run "github:MilesCranmer/rip2"` used by itself was not working is because the default app was not set, so nix was trying to execute `rip2` rather than `rip`. This change seems to fix it!

cc @kanielrkirby @koalazub