### PR TITLE
Fix #56 – race condition while writing `.record` from two concurrent processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,13 +615,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "regex-syntax",
 ]
 
@@ -633,9 +633,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
@@ -670,6 +670,7 @@ dependencies = [
  "lazy_static",
  "predicates 3.1.0",
  "rand",
+ "regex",
  "rstest",
  "tempfile",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6fcfb3c0c1d71612528825042261419d5dade9678c39a781e05b63677d9b32"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +665,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "dunce",
+ "fs4",
  "fs_extra",
  "lazy_static",
  "predicates 3.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ assert_cmd = "1.0"
 lazy_static = "1.4"
 predicates = "3.0"
 rand = "0.8"
+regex = "1.11.0"
 rstest = "0.18"
 tempfile = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.4", features = ["derive"] }
 clap_complete = "4.4"
 clap_complete_nushell = "4.4"
 dunce = "1.0.4"
+fs4 = { version = "0.10.0", features = ["sync"] }
 fs_extra = "1.3"
 walkdir = "1"
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This version, "rip2", is a fork-of-a-fork:
     - Features: colorful output, datetime info in seance, 
     - Bug fixes: FIFO files, issue with seance
     - Shell completions for bash, elvish, fish, powershell, zsh, and nushell (via clap)
+    - Thread safety for deletion record
 
 ## ⚰️ Installation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version, "rip2", is a fork-of-a-fork:
     - Added support for: Windows, NixOS
     - Cleanup: refactoring to modern rust, merging PRs from original repo
     - Testing: add full test suite and coverage monitoring
-    - Features: colorful output, datetime info in seance, 
+    - Features: colorful output, datetime info in seance
     - Bug fixes: FIFO files, issue with seance
     - Shell completions for bash, elvish, fish, powershell, zsh, and nushell (via clap)
     - Thread safety for deletion record

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
     }
 
     // Stores the deleted files
-    let record = Record::new(graveyard);
+    let record = Record::<true>::new(graveyard);
     let cwd = &env::current_dir()?;
 
     // If the user wishes to restore everything
@@ -119,10 +119,10 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
     Ok(())
 }
 
-fn bury_target(
+fn bury_target<const FILE_LOCK: bool>(
     target: &PathBuf,
     graveyard: &PathBuf,
-    record: &Record,
+    record: &Record<FILE_LOCK>,
     cwd: &Path,
     inspect: bool,
     mode: &impl util::TestingMode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod record;
 pub mod util;
 
 use args::Args;
-use record::{Record, RecordItem};
+use record::{Record, RecordItem, DEFAULT_FILE_LOCK};
 
 const LINES_TO_INSPECT: usize = 6;
 const FILES_TO_INSPECT: usize = 6;
@@ -42,7 +42,7 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
     }
 
     // Stores the deleted files
-    let record = Record::<true>::new(graveyard);
+    let record = Record::<DEFAULT_FILE_LOCK>::new(graveyard);
     let cwd = &env::current_dir()?;
 
     // If the user wishes to restore everything

--- a/src/record.rs
+++ b/src/record.rs
@@ -176,6 +176,9 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
 
         let already_existed = self.path.exists();
 
+        // TODO: The tiny amount of time between the check and the open
+        //       could allow for a race condition. But maybe I'm being overkill.
+
         let mut record_file = if already_existed {
             fs::OpenOptions::new().append(true).open(&self.path)?
         } else {

--- a/src/record.rs
+++ b/src/record.rs
@@ -42,6 +42,13 @@ pub struct Record<const FILE_LOCK: bool> {
     path: PathBuf,
 }
 
+#[cfg(not(target_os = "windows"))]
+pub const DEFAULT_FILE_LOCK: bool = true;
+
+#[cfg(target_os = "windows")]
+pub const DEFAULT_FILE_LOCK: bool = false;
+// TODO: Investigate why this is needed. Does Windows not support file locks?
+
 impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
     pub fn new(graveyard: &Path) -> Record<FILE_LOCK> {
         let path = graveyard.join(RECORD);

--- a/src/record.rs
+++ b/src/record.rs
@@ -30,6 +30,13 @@ impl RecordItem {
     }
 }
 
+/// A record of file operations maintained in the graveyard directory
+///
+/// # Type Parameters
+///
+/// * `FILE_LOCK` - When `true`, exclusive file locks are acquired when opening
+///   the record file for reading or writing. This prevents concurrent access from multiple
+///   processes. When `false`, no file locking is performed - which is used for testing.
 #[derive(Debug)]
 pub struct Record<const FILE_LOCK: bool> {
     path: PathBuf,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -638,7 +638,7 @@ fn issue_0018() {
         assert!(!record_contents.contains("gnu_meta.zip"));
 
         // And give this for the last bury
-        let record = record::Record::<true>::new(&test_env.graveyard);
+        let record = record::Record::<{record::DEFAULT_FILE_LOCK}>::new(&test_env.graveyard);
         let last_bury = record.get_last_bury().unwrap();
         assert!(last_bury.ends_with("uu_meta.zip"));
     }
@@ -708,7 +708,7 @@ fn read_empty_record() {
     let test_env = TestEnv::new();
     let cwd = env::current_dir().unwrap();
     fs::create_dir(&test_env.graveyard).unwrap();
-    let record = record::Record::<true>::new(&test_env.graveyard);
+    let record = record::Record::<{record::DEFAULT_FILE_LOCK}>::new(&test_env.graveyard);
     let gravepath = &util::join_absolute(&test_env.graveyard, dunce::canonicalize(cwd).unwrap());
     let result = record.seance(gravepath);
     assert!(result.is_ok());
@@ -990,8 +990,11 @@ fn test_bury_unbury_bury_unbury() {
 }
 
 /// Test concurrent writes to the pre-existing record file
+#[cfg(not(target_os = "windows"))]
 #[rstest]
-fn test_concurrent_writes(#[values(false, true)] file_lock: bool) {
+fn test_concurrent_writes(
+    #[values(true, false)] file_lock: bool
+) {
     if file_lock {
         _test_concurrent_writes::<true>();
     } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,6 @@ use lazy_static::lazy_static;
 use predicates::str::is_match;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use regex;
 use rip2::args::Args;
 use rip2::record;
 use rip2::util::TestMode;
@@ -910,8 +909,8 @@ fn test_bury_unbury_bury_unbury() {
 
     // Get the record file's contents:
     let record_path = test_env.graveyard.join(record::RECORD);
-    assert!(record_path.exists());
-    let record_contents = fs::read_to_string(&record_path).unwrap();
+    assert!(record_path.clone().exists());
+    let record_contents = fs::read_to_string(record_path.clone()).unwrap();
     println!("Initial record contents:\n{}", record_contents);
 
     assert!(record_contents.contains(&normalized_test_data_path.display().to_string()));
@@ -935,8 +934,8 @@ fn test_bury_unbury_bury_unbury() {
     assert_eq!(restored_data, test_data.data);
 
     // Get the new record file's contents:
-    assert!(record_path.exists());
-    let record_contents = fs::read_to_string(&record_path).unwrap();
+    assert!(record_path.clone().exists());
+    let record_contents = fs::read_to_string(record_path.clone()).unwrap();
     println!("After first unbury, record contents:\n{}", record_contents);
 
     // The record should still have the header:
@@ -1045,7 +1044,7 @@ fn _test_concurrent_writes<const FILE_LOCK: bool>() {
     handle1.join().unwrap();
     handle2.join().unwrap();
 
-    let record_contents = fs::read_to_string(&record_path).unwrap();
+    let record_contents = fs::read_to_string(record_path.clone()).unwrap();
 
     // The file should be perfectly formatted if `with_locking` is true,
     // but corrupted if it is not

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -638,7 +638,7 @@ fn issue_0018() {
         assert!(!record_contents.contains("gnu_meta.zip"));
 
         // And give this for the last bury
-        let record = record::Record::<{record::DEFAULT_FILE_LOCK}>::new(&test_env.graveyard);
+        let record = record::Record::<{ record::DEFAULT_FILE_LOCK }>::new(&test_env.graveyard);
         let last_bury = record.get_last_bury().unwrap();
         assert!(last_bury.ends_with("uu_meta.zip"));
     }
@@ -708,7 +708,7 @@ fn read_empty_record() {
     let test_env = TestEnv::new();
     let cwd = env::current_dir().unwrap();
     fs::create_dir(&test_env.graveyard).unwrap();
-    let record = record::Record::<{record::DEFAULT_FILE_LOCK}>::new(&test_env.graveyard);
+    let record = record::Record::<{ record::DEFAULT_FILE_LOCK }>::new(&test_env.graveyard);
     let gravepath = &util::join_absolute(&test_env.graveyard, dunce::canonicalize(cwd).unwrap());
     let result = record.seance(gravepath);
     assert!(result.is_ok());
@@ -992,9 +992,7 @@ fn test_bury_unbury_bury_unbury() {
 /// Test concurrent writes to the pre-existing record file
 #[cfg(not(target_os = "windows"))]
 #[rstest]
-fn test_concurrent_writes(
-    #[values(true, false)] file_lock: bool
-) {
+fn test_concurrent_writes(#[values(true, false)] file_lock: bool) {
     if file_lock {
         _test_concurrent_writes::<true>();
     } else {


### PR DESCRIPTION
Fixes #56 which also was present on the original `rip` repository. Basically there was no file locking in place to prevent two calls to `rip` from editing the `.record` file.

This PR uses [fs4](https://github.com/al8n/fs4-rs) to implement a file locking system. Therefore, two processes can safely make calls to `rip` without worrying about corrupting the `.record`.

This also adds an integration test for this behavior. That test also turns the file locking **off**, just to verify that in fact it does correctly test for race conditions (which it does). However I'm not sure how good Windows file locking system is, so we'll have to see how those CI do.