### PR TITLE
Speedup: cache env var

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -80,10 +80,7 @@ impl TestingMode for TestMode {
 
 pub fn allow_rename() -> bool {
     // Test behavior to skip simple rename
-    env::var("__RIP_ALLOW_RENAME")
-        .unwrap_or("true".to_string())
-        .parse::<bool>()
-        .unwrap()
+    env::var_os("__RIP_ALLOW_RENAME").map_or(true, |v| v != "false")
 }
 
 /// Prompt for user input, returning True if the first character is 'y' or 'Y'

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -104,7 +104,7 @@ fn test_filetypes(
     if copy {
         rip2::copy_file(&source_path, &dest_path, &mode, &mut log).unwrap();
     } else {
-        rip2::move_target(&source_path, &dest_path, &mode, &mut log).unwrap();
+        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log).unwrap();
     }
 
     let log_s = String::from_utf8(log).unwrap();


### PR DESCRIPTION
Seems like we were checking the env var `__RIP_ALLOW_RENAME` (purely for testing) every single time we moved a target. So this caches it within `rip2::run` and passes the result to each target. Also we avoid parsing, and just do equality checking.