### PR TITLE
Improve handling of timestamps and headers, with explicit errors for old rip format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,12 +103,8 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
         let gravepath = util::join_absolute(graveyard, dunce::canonicalize(cwd)?);
         writeln!(stream, "{: <19}\tpath", "deletion_time")?;
         for grave in record.seance(&gravepath)? {
-            let parsed_time = chrono::DateTime::parse_from_rfc3339(&grave.time)
-                .expect("Failed to parse time from RFC3339 format")
-                .format("%Y-%m-%dT%H:%M:%S")
-                .to_string();
-            // Get the path separator:
-            writeln!(stream, "{}\t{}", parsed_time, grave.dest.display())?;
+            let formatted_time = grave.format_time_for_display()?;
+            writeln!(stream, "{}\t{}", formatted_time, grave.dest.display())?;
         }
     } else if cli.targets.is_empty() {
         Args::command().print_help()?;

--- a/src/record.rs
+++ b/src/record.rs
@@ -89,6 +89,8 @@ pub const DEFAULT_FILE_LOCK: bool = false;
 // TODO: Investigate why this is needed. Does Windows not support file locks?
 
 impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
+    const HEADER: &'static str = "Time\tOriginal\tDestination";
+
     pub fn new(graveyard: &Path) -> Record<FILE_LOCK> {
         let path = graveyard.join(RECORD);
         // Create the record file if it doesn't exist
@@ -103,8 +105,7 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
             if FILE_LOCK {
                 record_file.lock_exclusive().unwrap();
             }
-            record_file
-                .write_all(b"Time\tOriginal\tDestination\n")
+            writeln!(record_file, "{}", Self::HEADER)
                 .expect("Failed to write header to record file");
         }
         Record { path }
@@ -126,14 +127,15 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
         // record: impl AsRef<Path>
         let record_file = self.open()?;
         let mut contents = String::new();
-        BufReader::new(&record_file).read_to_string(&mut contents)?;
+        {
+            let mut reader = self.skip_header(BufReader::new(&record_file))?;
+            reader.read_to_string(&mut contents)?;
+        }
 
         // This will be None if there is nothing, or Some
         // if there is items in the vector
         let mut graves_to_exhume: Vec<PathBuf> = Vec::new();
-        let mut lines = contents.lines();
-        lines.next();
-        for entry in lines.rev().map(RecordItem::new) {
+        for entry in contents.lines().rev().map(RecordItem::new) {
             // Check that the file is still in the graveyard.
             // If it is, return the corresponding line.
             if util::symlink_exists(&entry.dest) {
@@ -155,29 +157,24 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
 
     /// Takes a vector of grave paths and removes the respective lines from the record
     fn delete_lines(&self, record_file: fs::File, graves: &[PathBuf]) -> Result<(), Error> {
-        let record_path = &self.path;
         // Get the lines to write back to the record, which is every line except
         // the ones matching the exhumed graves. Store them in a vector
         // since we'll be overwriting the record in-place.
-        let mut reader = BufReader::new(record_file).lines();
-        let header = reader
-            .next()
-            .unwrap_or_else(|| Ok(String::new()))
-            .unwrap_or_default(); // Capture the header
+        let reader = self.skip_header(BufReader::new(record_file))?;
         let lines_to_write: Vec<String> = reader
+            .lines()
             .map_while(Result::ok)
             .filter(|line| !graves.iter().any(|y| *y == RecordItem::new(line).dest))
             .collect();
-        // let mut new_record_file = fs::File::create(record_path)?;
         let mut new_record_file = fs::OpenOptions::new()
             .create(true)
             .truncate(true)
             .write(true)
-            .open(record_path)?;
+            .open(&self.path)?;
         if FILE_LOCK {
             new_record_file.lock_exclusive().unwrap();
         }
-        writeln!(new_record_file, "{}", header)?; // Write the header back
+        writeln!(new_record_file, "{}", Self::HEADER)?; // Write the header back
         for line in lines_to_write {
             writeln!(new_record_file, "{}", line)?;
         }
@@ -202,9 +199,9 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
         graves: &'a [PathBuf],
     ) -> impl Iterator<Item = String> + 'a {
         let record_file = self.open().unwrap();
-        let mut reader = BufReader::new(record_file).lines();
-        reader.next();
+        let reader = self.skip_header(BufReader::new(record_file)).unwrap();
         reader
+            .lines()
             .map_while(Result::ok)
             .filter(move |line| graves.iter().any(|y| *y == RecordItem::new(line).dest))
     }
@@ -215,9 +212,9 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
         gravepath: &'a PathBuf,
     ) -> io::Result<impl Iterator<Item = RecordItem> + 'a> {
         let record_file = self.open()?;
-        let mut reader = BufReader::new(record_file).lines();
-        reader.next();
+        let reader = self.skip_header(BufReader::new(record_file))?;
         Ok(reader
+            .lines()
             .map_while(Result::ok)
             .map(|line| RecordItem::new(&line))
             .filter(move |record_item| record_item.dest.starts_with(gravepath)))
@@ -227,27 +224,10 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
     pub fn write_log(&self, source: impl AsRef<Path>, dest: impl AsRef<Path>) -> io::Result<()> {
         let (source, dest) = (source.as_ref(), dest.as_ref());
 
-        let already_existed = self.path.exists();
-
-        // TODO: The tiny amount of time between the check and the open
-        //       could allow for a race condition. But maybe I'm being overkill.
-
-        let mut record_file = if already_existed {
-            fs::OpenOptions::new().append(true).open(&self.path)?
-        } else {
-            fs::OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .open(&self.path)?
-        };
+        let mut record_file = fs::OpenOptions::new().append(true).open(&self.path)?;
 
         if FILE_LOCK {
             record_file.lock_exclusive().unwrap();
-        }
-
-        if !already_existed {
-            writeln!(record_file, "Time\tOriginal\tDestination")?;
         }
 
         writeln!(
@@ -265,6 +245,26 @@ impl<const FILE_LOCK: bool> Record<FILE_LOCK> {
         })?;
 
         Ok(())
+    }
+
+    /// Validates the header of a record file and returns the reader positioned after the header.
+    /// Returns Err if the header is invalid.
+    fn skip_header<R: BufRead>(&self, mut reader: R) -> io::Result<R> {
+        let mut header = String::new();
+        reader.read_line(&mut header)?;
+
+        if header.trim() != Self::HEADER {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Invalid record file header at {}:\n  Expected: '{}'\n  Got:      '{}'",
+                    &self.path.display(),
+                    Self::HEADER,
+                    header.trim()
+                ),
+            ));
+        }
+        Ok(reader)
     }
 }
 


### PR DESCRIPTION
This also:
1. Refactors a lot of the `Record` and `RecordItem` structs to eliminate code reuse.
2. Removes the extra file creation step within `write_log` to be similar in function to the other steps.

This fixes #67 by giving a more helpful error message for inability to parse the date format due to usage of old rip.

@chrisgeo do you think this would be worth it? It would also be helpful if you could test it on your "real-world" corrupted `.record`! I try to simulate a couple but want to make sure it works for yours as well.