### PR TITLE
Add `-f,--force` flag to force operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,7 @@ The `-f --force` flag enables non-interactive mode, which skips most prompts and
 
 - Big files are copied to the graveyard without prompting
 - Files already in the graveyard are permanently deleted without prompting
-- Special files (like sockets) will error
-- Cannot be used with `-i --inspect` flag
-
-This is useful for scripting or when you want to delete a lot of files without repeatedly answering prompts.
-
+- Special, non-movable files will error
 
 **Miscellaneous.**
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Options:
   -d, --decompose              Permanently deletes the graveyard
   -s, --seance                 Prints files that were deleted in the current directory
   -u, --unbury                 Restore the specified files or the last file if none are specified
-  -i, --inspect                Print some info about TARGET before burying
+  -i, --inspect                Print some info about FILES before burying
   -f, --force                  Non-interactive mode
   -h, --help                   Print help
   -V, --version                Print version

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Options:
   -s, --seance                 Prints files that were deleted in the current directory
   -u, --unbury                 Restore the specified files or the last file if none are specified
   -i, --inspect                Print some info about TARGET before burying
+  -f, --force                  Non-interactive mode
   -h, --help                   Print help
   -V, --version                Print version
 
@@ -231,6 +232,18 @@ If you want to put the graveyard somewhere else (like `~/.local/share/Trash`), y
   2. Set the environment variable `$RIP_GRAVEYARD` to `~/.local/share/Trash`.
 
 This can be a good idea because if the graveyard is mounted on an in-memory file system (as `/tmp` is in Arch Linux), deleting large files can quickly fill up your RAM. It's also much slower to move files across file systems, although the delay should be minimal with an SSD.
+
+**Force mode.**
+
+The `-f --force` flag enables non-interactive mode, which skips most prompts and uses default actions:
+
+- Big files are copied to the graveyard without prompting
+- Files already in the graveyard are permanently deleted without prompting
+- Special files (like sockets) will error
+- Cannot be used with `-i --inspect` flag
+
+This is useful for scripting or when you want to delete a lot of files without repeatedly answering prompts.
+
 
 **Miscellaneous.**
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This can be a good idea because if the graveyard is mounted on an in-memory file
 
 **Force mode.**
 
-The `-f --force` flag enables non-interactive mode, which skips most prompts and uses default actions:
+The `-f --force` flag enables non-interactive mode, which skips most prompts and automatically uses safe and reasonable behavior:
 
 - Big files are copied to the graveyard without prompting
 - Files already in the graveyard are permanently deleted without prompting

--- a/src/args.rs
+++ b/src/args.rs
@@ -107,6 +107,10 @@ pub struct Args {
     #[arg(short, long)]
     pub inspect: bool,
 
+    /// Non-interactive mode
+    #[arg(short, long)]
+    pub force: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }
@@ -137,6 +141,7 @@ struct IsDefault {
     seance: bool,
     unbury: bool,
     inspect: bool,
+    force: bool,
     completions: bool,
 }
 
@@ -149,6 +154,7 @@ impl IsDefault {
             seance: cli.seance == defaults.seance,
             unbury: cli.unbury == defaults.unbury,
             inspect: cli.inspect == defaults.inspect,
+            force: cli.force == defaults.force,
             completions: cli.command.is_none(),
         }
     }
@@ -164,7 +170,8 @@ pub fn validate_args(cli: &Args) -> Result<(), Error> {
             && defaults.decompose
             && defaults.seance
             && defaults.unbury
-            && defaults.inspect)
+            && defaults.inspect
+            && defaults.force)
     {
         return Err(Error::new(
             ErrorKind::InvalidInput,
@@ -175,6 +182,14 @@ pub fn validate_args(cli: &Args) -> Result<(), Error> {
         return Err(Error::new(
             ErrorKind::InvalidInput,
             "-d,--decompose can only be used with --graveyard",
+        ));
+    }
+
+    // Force and inspect are incompatible
+    if !defaults.force && !defaults.inspect {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "-f,--force and -i,--inspect cannot be used together",
         ));
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -102,7 +102,7 @@ pub struct Args {
     #[arg(short, long, num_args = 0)]
     pub unbury: Option<Vec<PathBuf>>,
 
-    /// Print some info about TARGET before
+    /// Print some info about FILES before
     /// burying
     #[arg(short, long)]
     pub inspect: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
 
     // If the user wishes to restore everything
     if cli.decompose {
-        if util::prompt_yes("Really unlink the entire graveyard?", &mode, stream)? {
+        // In force mode, skip the prompt to decompose
+        if cli.force || util::prompt_yes("Really unlink the entire graveyard?", &mode, stream)? {
             fs::remove_dir_all(graveyard)?;
         }
     } else if let Some(mut graves_to_exhume) = cli.unbury {
@@ -81,16 +82,18 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
                 true => util::rename_grave(&entry.orig),
                 false => PathBuf::from(&entry.orig),
             };
-            move_target(&entry.dest, &orig, allow_rename, &mode, stream).map_err(|e| {
-                Error::new(
-                    e.kind(),
-                    format!(
-                        "Unbury failed: couldn't copy files from {} to {}",
-                        entry.dest.display(),
-                        orig.display()
-                    ),
-                )
-            })?;
+            move_target(&entry.dest, &orig, allow_rename, &mode, stream, cli.force).map_err(
+                |e| {
+                    Error::new(
+                        e.kind(),
+                        format!(
+                            "Unbury failed: couldn't copy files from {} to {}",
+                            entry.dest.display(),
+                            orig.display()
+                        ),
+                    )
+                },
+            )?;
             writeln!(
                 stream,
                 "Returned {} to {}",
@@ -120,6 +123,7 @@ pub fn run(cli: Args, mode: impl util::TestingMode, stream: &mut impl Write) -> 
                 allow_rename,
                 &mode,
                 stream,
+                cli.force,
             )?;
         }
     }
@@ -137,6 +141,7 @@ fn bury_target<const FILE_LOCK: bool>(
     allow_rename: bool,
     mode: &impl util::TestingMode,
     stream: &mut impl Write,
+    force: bool,
 ) -> Result<(), Error> {
     // Check if source exists
     let metadata = &fs::symlink_metadata(target).map_err(|_| {
@@ -161,8 +166,16 @@ fn bury_target<const FILE_LOCK: bool>(
     } else if source.starts_with(graveyard) {
         // If rip is called on a file already in the graveyard, prompt
         // to permanently delete it instead.
-        writeln!(stream, "{} is already in the graveyard.", source.display())?;
-        if util::prompt_yes("Permanently unlink it?", mode, stream)? {
+        if force
+            || util::prompt_yes(
+                format!(
+                    "{} is already in the graveyard.\nPermanently unlink it?",
+                    source.display()
+                ),
+                mode,
+                stream,
+            )?
+        {
             if fs::remove_dir_all(source).is_err() {
                 fs::remove_file(source).map_err(|e| {
                     Error::new(e.kind(), format!("Couldn't unlink {}", source.display()))
@@ -185,7 +198,7 @@ fn bury_target<const FILE_LOCK: bool>(
             }
         };
 
-        let moved = move_target(source, dest, allow_rename, mode, stream).map_err(|e| {
+        let moved = move_target(source, dest, allow_rename, mode, stream, force).map_err(|e| {
             fs::remove_dir_all(dest).ok();
             Error::new(e.kind(), "Failed to bury file")
         })?;
@@ -270,6 +283,7 @@ pub fn move_target(
     allow_rename: bool,
     mode: &impl util::TestingMode,
     stream: &mut impl Write,
+    force: bool,
 ) -> Result<bool, Error> {
     // Try a simple rename, which will only work within the same mount point.
     // Trying to rename across filesystems will throw errno 18.
@@ -284,9 +298,9 @@ pub fn move_target(
     )?;
 
     if fs::symlink_metadata(target)?.is_dir() {
-        move_dir(target, dest, mode, stream)
+        move_dir(target, dest, mode, stream, force)
     } else {
-        let moved = copy_file(target, dest, mode, stream).map_err(|e| {
+        let moved = copy_file(target, dest, mode, stream, force).map_err(|e| {
             Error::new(
                 e.kind(),
                 format!(
@@ -313,6 +327,7 @@ pub fn move_dir(
     dest: &Path,
     mode: &impl util::TestingMode,
     stream: &mut impl Write,
+    force: bool,
 ) -> Result<bool, Error> {
     // Walk the source, creating directories and copying files as needed
     for entry in WalkDir::new(target).into_iter().filter_map(|e| e.ok()) {
@@ -336,7 +351,7 @@ pub fn move_dir(
                 )
             })?;
         } else {
-            copy_file(entry.path(), &dest.join(orphan), mode, stream).map_err(|e| {
+            copy_file(entry.path(), &dest.join(orphan), mode, stream, force).map_err(|e| {
                 Error::new(
                     e.kind(),
                     format!(
@@ -363,18 +378,24 @@ pub fn copy_file(
     dest: &Path,
     mode: &impl util::TestingMode,
     stream: &mut impl Write,
+    force: bool,
 ) -> Result<bool, Error> {
     let metadata = fs::symlink_metadata(source)?;
     let filetype = metadata.file_type();
 
     if metadata.len() > BIG_FILE_THRESHOLD {
-        writeln!(
-            stream,
-            "About to copy a big file ({} is {})",
-            source.display(),
-            util::humanize_bytes(metadata.len())
-        )?;
-        if util::prompt_yes("Permanently delete this file instead?", mode, stream)? {
+        // In force mode, we default to copying big files
+        if !force
+            && util::prompt_yes(
+                format!(
+                    "About to copy a big file ({} is {})\nPermanently delete this file instead?",
+                    source.display(),
+                    util::humanize_bytes(metadata.len())
+                ),
+                mode,
+                stream,
+            )?
+        {
             return Ok(false);
         }
     }
@@ -404,13 +425,17 @@ pub fn copy_file(
     match fs::copy(source, dest) {
         Err(e) => {
             // Special file: Try copying it as normal, but this probably won't work
-            writeln!(
-                stream,
-                "Non-regular file or directory: {}",
-                source.display()
-            )?;
-
-            if util::prompt_yes("Permanently delete the file?", mode, stream)? {
+            // In force mode, we don't delete special files, we error
+            if !force
+                && util::prompt_yes(
+                    format!(
+                        "Non-regular file or directory: {}\nPermanently delete the file?",
+                        source.display()
+                    ),
+                    mode,
+                    stream,
+                )?
+            {
                 Ok(false)
             } else {
                 Err(e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,10 @@ fn bury_target<const FILE_LOCK: bool>(
 
     if inspect && !should_we_bury_this(target, source, metadata, mode, stream)? {
         // User chose to not bury the file
-    } else if source.starts_with(graveyard) {
+    } else if source.starts_with(
+        dunce::canonicalize(graveyard)
+            .map_err(|e| Error::new(e.kind(), "Failed to canonicalize graveyard path"))?,
+    ) {
         // If rip is called on a file already in the graveyard, prompt
         // to permanently delete it instead.
         if force

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -102,9 +102,9 @@ fn test_filetypes(
     let mode = TestMode;
 
     if copy {
-        rip2::copy_file(&source_path, &dest_path, &mode, &mut log).unwrap();
+        rip2::copy_file(&source_path, &dest_path, &mode, &mut log, false).unwrap();
     } else {
-        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log).unwrap();
+        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log, false).unwrap();
     }
 
     let log_s = String::from_utf8(log).unwrap();
@@ -251,7 +251,7 @@ fn fail_move_dir() {
     let dest = path_dest.join("foo");
     let target = path_target.join("bar");
     let mut log = Vec::new();
-    let results = rip2::move_dir(&target, &dest, &TestMode, &mut log);
+    let results = rip2::move_dir(&target, &dest, &TestMode, &mut log, false);
     assert!(results.is_err());
     if let Err(e) = results {
         assert!(e.to_string().contains("Failed to remove dir"));


### PR DESCRIPTION
The force operation should basically do the least unexpected/harmful thing in all cases.

1. When `rip` is applied to a large file, it will copy it without asking, rather than deleting it (which would be dangerous).
2. However, when used with `rip -d -f` (decompose the graveyard), it will decompose without asking. This is a pretty explicit command so seems like better default behavior.
3. It will error if you try to use it with `-i,--inspect` mode, since those are obviously incompatible.
4. Will also error on special files, instead of prompting the user. I think this is safer than simply deleting, since the special file might be unexpected.

Fixes #52 