### PR TITLE
fix: args not consumed by unbury

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -99,7 +99,7 @@ pub struct Args {
     /// Restore the specified
     /// files or the last file
     /// if none are specified
-    #[arg(short, long, num_args = 0)]
+    #[arg(short, long, num_args = 0..)]
     pub unbury: Option<Vec<PathBuf>>,
 
     /// Print some info about FILES before


### PR DESCRIPTION
Fixes #112 

Extremely subtle thing about the clap parsing. This was somehow not caught by the existing integration testing because they skip the arg parsing step. So maybe this means we need to have more of the tests work directly with the clap interface.