### PR TITLE
fix: fifo keeping same permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +463,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +658,7 @@ dependencies = [
  "fs4",
  "fs_extra",
  "lazy_static",
+ "nix",
  "predicates",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ fs4 = { version = "0.12.0", features = ["sync"] }
 fs_extra = "1.3"
 walkdir = "2"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["fs"] }
+
 [dev-dependencies]
 assert_cmd = "2"
 lazy_static = "1.4"


### PR DESCRIPTION
This is related to an issue where moving a FIFO pipe to the graveyard would change its permission mode. We fix this by using a proper `mkfifo` call from the nix crate rather than using a subprocess and calling the mkfifo command.