### PR TITLE
fix: propagate parent directory permissions to graveyard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,12 +47,8 @@ pub fn run(cli: &Args, mode: impl util::TestingMode, stream: &mut impl Write) ->
 
         #[cfg(unix)]
         {
-            let metadata = graveyard.metadata()?;
-            let mut permissions = metadata.permissions();
-            permissions.set_mode(0o700);
-            fs::set_permissions(graveyard, permissions)?;
+            fs::set_permissions(graveyard, fs::Permissions::from_mode(0o700))?;
         }
-        // TODO: Default permissions on windows should be good, but need to double-check.
     }
 
     // Stores the deleted files

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,6 @@ pub struct DirToCreate {
     pub permissions: Option<fs::Permissions>,
 }
 
-impl DirToCreate {
-    fn new(path: PathBuf, permissions: Option<fs::Permissions>) -> Self {
-        Self { path, permissions }
-    }
-}
-
 // Platform-specific imports
 #[cfg(unix)]
 use nix::libc;
@@ -316,7 +310,7 @@ fn should_we_bury_this(
     )
 }
 
-/// Build destination path and collect directory permissions to preserve
+/// Plan graveyard directory structure and permissions
 fn build_graveyard_dest(graveyard: &Path, source: &Path) -> (PathBuf, Vec<DirToCreate>) {
     let mut dest = graveyard.to_path_buf();
     let mut dirs_to_create = Vec::new();
@@ -333,7 +327,10 @@ fn build_graveyard_dest(graveyard: &Path, source: &Path) -> (PathBuf, Vec<DirToC
                 let permissions = fs::metadata(&cumulative_source)
                     .map(|m| m.permissions())
                     .ok();
-                dirs_to_create.push(DirToCreate::new(dest.clone(), permissions));
+                dirs_to_create.push(DirToCreate {
+                    path: dest.clone(),
+                    permissions,
+                });
             }
         }
     }
@@ -341,7 +338,7 @@ fn build_graveyard_dest(graveyard: &Path, source: &Path) -> (PathBuf, Vec<DirToC
     (dest, dirs_to_create)
 }
 
-/// Build directory structure with permissions from graveyard for unbury
+/// Plan source directory structure and permissions
 fn build_dirs_to_create_from_graveyard(
     graveyard_path: &Path,
     orig_path: &Path,
@@ -354,7 +351,10 @@ fn build_dirs_to_create_from_graveyard(
 
     while let (Some(g), Some(o)) = (graveyard_current, orig_current) {
         let permissions = fs::metadata(g).map(|m| m.permissions()).ok();
-        dirs_to_create.push(DirToCreate::new(o.to_path_buf(), permissions));
+        dirs_to_create.push(DirToCreate {
+            path: o.to_path_buf(),
+            permissions,
+        });
 
         // Move up one level
         graveyard_current = g.parent();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,7 +421,7 @@ pub fn move_dir(
                     ),
                 )
             })?;
-            
+
             // Preserve directory permissions
             let source_metadata = fs::metadata(entry.path()).map_err(|e| {
                 Error::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run(cli: &Args, mode: impl util::TestingMode, stream: &mut impl Write) ->
             let metadata = graveyard.metadata()?;
             let mut permissions = metadata.permissions();
             permissions.set_mode(0o700);
+            fs::set_permissions(graveyard, permissions)?;
         }
         // TODO: Default permissions on windows should be good, but need to double-check.
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,16 @@ fn create_dirs_with_permissions(source: &Path, dest: &Path) -> Result<(), Error>
                         let dest_dir = dest_components[i + offset];
                         // Only set permissions if the directory exists (which it should after create_dir_all)
                         if dest_dir.exists() {
-                            let _ = fs::set_permissions(dest_dir, src_meta.permissions());
+                            fs::set_permissions(dest_dir, src_meta.permissions()).map_err(|e| {
+                                Error::new(
+                                    e.kind(),
+                                    format!(
+                                        "Failed to preserve permissions on directory '{}': {}. The directory may be owned by another user.",
+                                        dest_dir.display(),
+                                        e
+                                    ),
+                                )
+                            })?;
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,8 @@ pub fn move_target(
     // If that didn't work, then we need to copy and rm.
     if let Some(dirs) = dirs_to_create {
         create_dirs_with_permissions(dirs)?;
+    } else if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
     }
 
     if fs::symlink_metadata(target)?.is_dir() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,26 +371,12 @@ fn create_dirs_with_permissions(dirs_to_create: &[DirToCreate]) -> Result<(), Er
     for dir in dirs_to_create {
         if !dir.path.exists() {
             // Create just this directory (parent should already exist)
-            fs::create_dir(&dir.path)
-                .or_else(|e| {
-                    // If parent doesn't exist, create it with default permissions
-                    if e.kind() == ErrorKind::NotFound {
-                        if let Some(parent) = dir.path.parent() {
-                            fs::create_dir_all(parent)?;
-                            fs::create_dir(&dir.path)
-                        } else {
-                            Err(e)
-                        }
-                    } else {
-                        Err(e)
-                    }
-                })
-                .map_err(|e| {
-                    Error::new(
-                        e.kind(),
-                        format!("Failed to create directory {}: {}", dir.path.display(), e),
-                    )
-                })?;
+            fs::create_dir(&dir.path).map_err(|e| {
+                Error::new(
+                    e.kind(),
+                    format!("Failed to create directory {}: {}", dir.path.display(), e),
+                )
+            })?;
 
             // Set permissions if we have them
             if let Some(perms) = &dir.permissions {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1514,7 +1514,7 @@ fn test_directory_permissions_preserved() {
 
     // Rip the file from within the private directory
     let result = rip2::run(
-        Args {
+        &Args {
             targets: vec![secret_file.clone()],
             graveyard: Some(test_env.graveyard.clone()),
             ..Args::default()
@@ -1596,7 +1596,7 @@ fn test_deeply_nested_directory_permissions() {
 
     // Rip the deeply nested file
     let result = rip2::run(
-        Args {
+        &Args {
             targets: vec![deep_file.clone()],
             graveyard: Some(test_env.graveyard.clone()),
             ..Args::default()
@@ -1687,7 +1687,7 @@ fn test_directory_rip_vs_file_rip_permissions() {
 
     // Test 1: Rip the entire directory structure
     let result1 = rip2::run(
-        Args {
+        &Args {
             targets: vec![dir_structure1.clone()],
             graveyard: Some(test_env.graveyard.clone()),
             ..Args::default()
@@ -1699,7 +1699,7 @@ fn test_directory_rip_vs_file_rip_permissions() {
 
     // Test 2: Rip just the file from the second structure
     let result2 = rip2::run(
-        Args {
+        &Args {
             targets: vec![file2.clone()],
             graveyard: Some(test_env.graveyard.clone()),
             ..Args::default()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1759,25 +1759,25 @@ fn test_graveyard_maintains_700_permissions() {
     // This test ensures that the graveyard directory maintains its 700 permissions
     // even when files are moved from directories with different permissions (like 755).
     // This is critical for security - the graveyard should only be accessible by the owner.
-    
+
     let _env_lock = aquire_lock();
     let test_env = TestEnv::new();
-    
+
     // Create a source file in a directory with 755 permissions (standard permissions)
     let source_dir = test_env.src.join("public_dir");
     fs::create_dir_all(&source_dir).unwrap();
-    
+
     // Explicitly set the source directory to 755 to ensure we're testing the right scenario
     let mut perms = fs::metadata(&source_dir).unwrap().permissions();
     perms.set_mode(0o755);
     fs::set_permissions(&source_dir, perms).unwrap();
-    
+
     let test_file = source_dir.join("test.txt");
     fs::write(&test_file, "test content").unwrap();
-    
+
     // Canonicalize the path BEFORE ripping (since it won't exist after)
     let canonical_test_file = dunce::canonicalize(&test_file).unwrap();
-    
+
     // Run rip to move the file to the graveyard
     let result = rip2::run(
         &Args {
@@ -1788,23 +1788,24 @@ fn test_graveyard_maintains_700_permissions() {
         TestMode,
         &mut Vec::new(),
     );
-    
+
     assert!(result.is_ok(), "Failed to rip file");
-    
+
     // Check that the graveyard exists and has 700 permissions
     assert!(test_env.graveyard.exists(), "Graveyard should exist");
-    
+
     let graveyard_perms = fs::metadata(&test_env.graveyard)
         .unwrap()
         .permissions()
-        .mode() & 0o777;
-    
+        .mode()
+        & 0o777;
+
     assert_eq!(
         graveyard_perms, 0o700,
         "Graveyard should have 700 permissions (drwx------), but has {:o}",
         graveyard_perms
     );
-    
+
     // Also verify that files were successfully moved into the graveyard
     let dest_path = util::join_absolute(&test_env.graveyard, canonical_test_file);
     assert!(dest_path.exists(), "File should be moved to graveyard");

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -107,17 +107,7 @@ fn test_filetypes(
     if copy {
         rip2::copy_file(&source_path, &dest_path, &mode, &mut log, false).unwrap();
     } else {
-        let dirs_to_create = Vec::new();
-        rip2::move_target(
-            &source_path,
-            &dest_path,
-            true,
-            &mode,
-            &mut log,
-            false,
-            &dirs_to_create,
-        )
-        .unwrap();
+        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log, false, None).unwrap();
     }
 
     let log_s = String::from_utf8(log).unwrap();

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -107,7 +107,7 @@ fn test_filetypes(
     if copy {
         rip2::copy_file(&source_path, &dest_path, &mode, &mut log, false).unwrap();
     } else {
-        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log, false, None).unwrap();
+        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log, false, &[]).unwrap();
     }
 
     let log_s = String::from_utf8(log).unwrap();

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -107,7 +107,17 @@ fn test_filetypes(
     if copy {
         rip2::copy_file(&source_path, &dest_path, &mode, &mut log, false).unwrap();
     } else {
-        rip2::move_target(&source_path, &dest_path, true, &mode, &mut log, false).unwrap();
+        let dirs_to_create = Vec::new();
+        rip2::move_target(
+            &source_path,
+            &dest_path,
+            true,
+            &mode,
+            &mut log,
+            false,
+            &dirs_to_create,
+        )
+        .unwrap();
     }
 
     let log_s = String::from_utf8(log).unwrap();


### PR DESCRIPTION
One footgun that exists with rip, which was inherited from the original rip codebase, is that ripping a file does not propagate the *parent* directory permissions within the graveyard.

For most uses, this is ok. The default graveyard folder is not readable to other users (it is created with the equivalent of `chmod 700`). **(Edit: it seems like sometimes this was not the case. I have included a fix for this as well.)**

Furthermore, if you `rip ~/.ssh`, and `~/.ssh` is `rwx------`, then it will exist `rwx------` inside the graveyard.

If you `rip ~/.ssh/id_rsa`, and don't already have a graveyard folder equivalent to `.ssh`, the `fs::create_dir_all` function will create a folder with permission=777.

Again, this is not necessarily an issue, because the graveyard is permission=700.

The issue is that if you were to then:
1. Remove the `~/.ssh` folder with regular `/bin/rm -rf`, and then
2. Unbury the file `~/.ssh/id_rsa`

This will create a new directory `~/.ssh` with permissions equivalent to the graveyard for that directory!

The simple solution is to propagate permissions for all parent directories into the graveyard. While permission=700 for the entire graveyard, it is not enough, and you can have this edge case where unburying might create a parent directory with unexpected permissions.